### PR TITLE
Update Jenkinsfile syntax

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,2 +1,6 @@
-/* `buildPlugin` step provided by: https://github.com/jenkins-infra/pipeline-library */
-buildPlugin(configurations: buildPlugin.recommendedConfigurations())
+buildPlugin(
+  useContainerAgent: true,
+  configurations: [
+    [platform: 'linux', jdk: 8],
+    [platform: 'windows', jdk: 8],
+])


### PR DESCRIPTION
This PR removes the deprecated recommendedConfigurations syntax to favor a proper configuration.
Internally, recommendedConfigurations does no longer apply any configuration it used to apply years ago.

I'll expedite the merge, once the infrastructure changes to ci.jenkins.io have been merged into production, to prevent failing builds on the default branch and new pull requests.